### PR TITLE
Fixed #36

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -50,6 +50,8 @@ var pgMiddleware = function(_dbOptions){
     dbOptions.poolSize = dbOptions.poolSize || 64;
   }
 
+  var pool = new pg.Pool(dbOptions);
+
   return function(req, res, next){
     req.db = {};
     req.db.query = function(sql, bindvars, callback){
@@ -63,8 +65,6 @@ var pgMiddleware = function(_dbOptions){
         poolTimedOut = true;
         callback(new Error('failed to get db connection'));
       }, 5000);
-
-      var pool = new pg.Pool(dbOptions);
       
       pool.connect(function(err, client, done){
         if (poolTimedOut) {


### PR DESCRIPTION
Currently, a pg pool was created for each request : this is bad, as each pool keeps a connection to the db so it can reuse it. This caused issue #36 for me. 
By following the example here : https://github.com/brianc/node-postgres/tree/v6.4.1 the pool must be created only once, and reused across requests (that's the purpose of a pool).

For info, this probably origined after the changes made to the pg lib, which switched from a singleton to a pg Pool instance when updating to v6.x